### PR TITLE
feat: endpoint de criação e listagem de agendamentos

### DIFF
--- a/backend/src/main/java/com/smilecorp/SmileCorp/controller/AgendamentoController.java
+++ b/backend/src/main/java/com/smilecorp/SmileCorp/controller/AgendamentoController.java
@@ -1,0 +1,131 @@
+package com.smilecorp.SmileCorp.controller;
+
+import com.smilecorp.SmileCorp.model.Agendamento;
+import com.smilecorp.SmileCorp.model.Paciente; // Ensure this is imported
+import com.smilecorp.SmileCorp.model.Profissional;
+import com.smilecorp.SmileCorp.repository.AgendamentoRepository;
+import com.smilecorp.SmileCorp.repository.PacienteRepository; // Need this for find/save
+import com.smilecorp.SmileCorp.repository.ProfissionalRepository;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/agendamentos") // Matches your frontend URL
+public class AgendamentoController {
+
+    private final AgendamentoRepository repository;
+    private final PacienteRepository pacienteRepository;
+    private final ProfissionalRepository profissionalRepository;
+
+    public AgendamentoController(AgendamentoRepository repository, PacienteRepository pacienteRepository, ProfissionalRepository profissionalRepository) {
+        this.repository = repository;
+        this.pacienteRepository = pacienteRepository;
+        this.profissionalRepository = profissionalRepository;
+    }
+
+    // LISTAR TODOS COM FILTROS
+    @GetMapping
+    public List<Agendamento> listar(
+            @RequestParam(required = false) String doctor,
+            @RequestParam(required = false) String patient,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate) {
+        List<Agendamento> all = repository.findAll();
+        return all.stream().filter(a -> {
+            if (doctor != null && (a.getProfissional() == null || !a.getProfissional().getNome().equals(doctor)))
+                return false;
+            if (patient != null && (a.getPaciente() == null
+                    || !a.getPaciente().getNome().toLowerCase().contains(patient.toLowerCase())))
+                return false;
+            if (startDate != null && a.getData().compareTo(startDate) < 0)
+                return false;
+            if (endDate != null && a.getData().compareTo(endDate) > 0)
+                return false;
+            return true;
+        }).collect(Collectors.toList());
+    }
+
+    @PostMapping
+    public Agendamento inserir(@RequestBody Map<String, Object> payload) {
+        Agendamento a = new Agendamento();
+
+        // --- 1. Lógica do Paciente --- 
+        @SuppressWarnings("unchecked")
+        Map<String, Object> pData = (Map<String, Object>) payload.get("paciente");
+        if (pData != null) {
+            if (pData.get("id") != null) {
+                Long id = Long.valueOf(pData.get("id").toString());
+                Paciente existing = pacienteRepository.findById(id).orElse(null);
+                if (existing != null) {
+                    a.setPaciente(existing);
+                } else {
+                    // Create new if not found
+                    Paciente p = new Paciente();
+                    p.setNome((String) pData.get("nome"));
+                    p.setEmail((String) pData.get("email"));
+                    p.setTelefone((String) pData.get("telefone"));
+                    a.setPaciente(p);
+                }
+            } else {
+                // Create new paciente
+                Paciente p = new Paciente();
+                p.setNome((String) pData.get("nome"));
+                p.setEmail((String) pData.get("email"));
+                p.setTelefone((String) pData.get("telefone"));
+                a.setPaciente(p);
+            }
+        }
+
+        // --- 2. Lógica do Profissional ---
+        @SuppressWarnings("unchecked")
+        Map<String, Object> profData = (Map<String, Object>) payload.get("profissional");
+        if (profData != null) {
+            if (profData.get("id") != null) {
+                Long id = Long.valueOf(profData.get("id").toString());
+                Profissional existing = profissionalRepository.findById(id).orElse(null);
+                if (existing != null) {
+                    a.setProfissional(existing);
+                } else {
+                    // Create new if not found
+                    Profissional prof = new Profissional();
+                    prof.setNome((String) profData.get("nome"));
+                    // Set other fields if provided
+                    if (profData.get("especialidade") != null) {
+                        prof.setEspecialidade((String) profData.get("especialidade"));
+                    }
+                    if (profData.get("registroProfissional") != null) {
+                        prof.setRegistroProfissional((String) profData.get("registroProfissional"));
+                    }
+                    a.setProfissional(prof);
+                }
+            } else {
+                // Create new profissional
+                Profissional prof = new Profissional();
+                prof.setNome((String) profData.get("nome"));
+                if (profData.get("especialidade") != null) {
+                    prof.setEspecialidade((String) profData.get("especialidade"));
+                }
+                if (profData.get("registroProfissional") != null) {
+                    prof.setRegistroProfissional((String) profData.get("registroProfissional"));
+                }
+                a.setProfissional(prof);
+            }
+        }
+
+        // --- 3. Restante dos campos (Data, Horários, etc) ---
+        a.setData((String) payload.get("data"));
+        a.setHorarioInicio((String) payload.get("horarioInicio"));
+        a.setPrevisaoTermino((String) payload.get("previsaoTermino"));
+        a.setObservacoes((String) payload.get("observacoes"));
+
+        // --- 4. Procedimentos ---
+        List<?> procIds = (List<?>) payload.get("procedimentosIds");
+        if (procIds != null) {
+            a.setProcedimentosIds(procIds.stream().map(obj -> Long.valueOf(obj.toString())).toList());
+        }
+
+        return repository.save(a);
+    }
+}

--- a/backend/src/main/java/com/smilecorp/SmileCorp/model/Agendamento.java
+++ b/backend/src/main/java/com/smilecorp/SmileCorp/model/Agendamento.java
@@ -1,0 +1,94 @@
+package com.smilecorp.SmileCorp.model;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+public class Agendamento {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "paciente_id", referencedColumnName = "id")
+    private Paciente paciente;
+
+    @ManyToOne
+    @JoinColumn(name = "profissional_id") // Isso cria a FK no banco
+    private Profissional profissional;
+
+    private String data;
+    private String horarioInicio;
+    private String previsaoTermino;
+
+    @Column(columnDefinition = "TEXT")
+    private String observacoes;
+
+    @ElementCollection
+    private List<Long> procedimentosIds;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Paciente getPaciente() {
+        return paciente;
+    }
+
+    public void setPaciente(Paciente paciente) {
+        this.paciente = paciente;
+    }
+
+    public Profissional getProfissional() {
+        return profissional;
+    }
+
+    public void setProfissional(Profissional profissional) {
+        this.profissional = profissional;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public String getHorarioInicio() {
+        return horarioInicio;
+    }
+
+    public void setHorarioInicio(String horarioInicio) {
+        this.horarioInicio = horarioInicio;
+    }
+
+    public String getPrevisaoTermino() {
+        return previsaoTermino;
+    }
+
+    public void setPrevisaoTermino(String previsaoTermino) {
+        this.previsaoTermino = previsaoTermino;
+    }
+
+    public String getObservacoes() {
+        return observacoes;
+    }
+
+    public void setObservacoes(String observacoes) {
+        this.observacoes = observacoes;
+    }
+
+    public List<Long> getProcedimentosIds() {
+        return procedimentosIds;
+    }
+
+    public void setProcedimentosIds(List<Long> procedimentosIds) {
+        this.procedimentosIds = procedimentosIds;
+    }
+
+}

--- a/backend/src/main/java/com/smilecorp/SmileCorp/repository/AgendamentoRepository.java
+++ b/backend/src/main/java/com/smilecorp/SmileCorp/repository/AgendamentoRepository.java
@@ -1,0 +1,9 @@
+package com.smilecorp.SmileCorp.repository;
+
+import com.smilecorp.SmileCorp.model.Agendamento;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> {
+}


### PR DESCRIPTION
Apresentamos a entidade Agendamento JPA, seu repositório e controlador REST. A entidade inclui relacionamentos com Paciente (persistência em cascata) e Profissional, campos de data/hora, observações e uma ElementCollection para IDs de procedimentos. AgendamentoRepository estende JpaRepository. AgendamentoController expõe os métodos GET /api/agendamentos com filtros opcionais (médico, paciente, dataInicial, dataFinal) e POST para criar registros de Agendamento; o manipulador POST busca Paciente/Profissional existente por ID ou cria novos a partir do payload, mapeia os campos e salva através do repositório.